### PR TITLE
Fix-deps-install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
        fail-fast: false
        matrix:
         # 7.0.0-SNAPSHOT and 6.2.1 created
-         exist-version: [5.3.0, latest, release]
+         exist-version: [5.3.1, latest, release]
          java-version: [11, 17]
          exclude:
-           - exist-version: 5.3.0
+           - exist-version: 5.3.1
              java-version: 17
            - exist-version: release
              java-version: 17
@@ -45,6 +45,13 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
       - run: ant
+
+      # TODO(DP): temporary solution
+      - name: Install expath dependencies
+        working-directory: build
+        run: |
+          wget -O 01.xar http://exist-db.org/exist/apps/public-repo/public/functx-1.0.1.xar
+          wget -O 02.xar https://github.com/eXist-db/expath-crypto-module/releases/download/6.0.1/expath-crypto-module-6.0.1.xar
 
       # Install
       - name: Start exist-ci containers

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,11 @@ jobs:
        fail-fast: false
        matrix:
         # 7.0.0-SNAPSHOT and 6.2.1 created
-         exist-version: [latest, release]
+         exist-version: [5.3.0, latest, release]
          java-version: [11, 17]
          exclude:
+           - exist-version: 5.3.0
+             java-version: 17
            - exist-version: release
              java-version: 17
            - exist-version: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,9 @@ jobs:
        fail-fast: false
        matrix:
         # 7.0.0-SNAPSHOT and 6.2.1 created
-         exist-version: [5.3.1, latest, release]
+         exist-version: [latest, release]
          java-version: [11, 17]
          exclude:
-           - exist-version: 5.3.1
-             java-version: 17
            - exist-version: release
              java-version: 17
            - exist-version: latest

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="@url@" abbrev="@name@" version="@version@" spec="1.0">
     <title>@title@</title>
-    <dependency processor="http://exist-db.org" semver-min="5.3.0"/>
+    <dependency processor="http://exist-db.org" semver-min="6.0.0"/>
     <dependency package="http://www.functx.com"/>
     <dependency package="http://expath.org/ns/crypto"/>
     <xquery>

--- a/test/smoke-test.bats
+++ b/test/smoke-test.bats
@@ -25,7 +25,7 @@
 
 # Make sure the package has been deployed
 @test "logs show package deployment" {
-  result=$(docker logs exist | grep -o 'http://history.state.gov/ns/pkg/aws.xq')
+  result=$(docker logs exist | grep -o -m 1 'http://history.state.gov/ns/pkg/aws.xq')
   [ "$result" == 'http://history.state.gov/ns/pkg/aws.xq' ]
 }
 


### PR DESCRIPTION
adjust test
I added 5.3 to the test matrix as per the processor dep declared in the expath package, but that now leads to compatibility problems with the crypto package 

@joewiz how do you want me to proceed?
 -  Remove 5.3. from the matrix and bump the declared dependency, or (fast) 
 - keep the dependency and get the correct version of crypto to 5.3. to install on ci and (slower)

?

see https://github.com/eXist-db/expath-crypto-module/issues/64 